### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -34,7 +34,7 @@ jobs:
         draft: false
         prerelease: false
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: tzoght/heart_disease_predictor 
         username: ${{ secrets.DOCKER_USERNAME }} 


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore